### PR TITLE
Add text to the color picker view, which is off by default.

### DIFF
--- a/app/src/main/java/com/flask/colorpicker/sample/SampleActivity.java
+++ b/app/src/main/java/com/flask/colorpicker/sample/SampleActivity.java
@@ -7,6 +7,7 @@ import android.support.v7.app.ActionBarActivity;
 import android.view.View;
 import android.widget.Toast;
 
+import com.flask.colorpicker.builder.ColorPickerClickListener;
 import com.flask.colorpicker.builder.ColorPickerDialogBuilder;
 import com.flask.colorpicker.ColorPickerView;
 import com.flask.colorpicker.OnColorSelectedListener;
@@ -39,10 +40,24 @@ public class SampleActivity extends ActionBarActivity {
 								toast("onColorSelected: 0x" + Integer.toHexString(selectedColor));
 							}
 						})
-						.setPositiveButton("ok", new DialogInterface.OnClickListener() {
+						.setPositiveButton("ok", new ColorPickerClickListener() {
 							@Override
-							public void onClick(DialogInterface dialog, int selectedColor) {
+							public void onClick(DialogInterface dialog, int selectedColor, Integer[] allColors) {
 								changeBackgroundColor(selectedColor);
+								if (allColors != null) {
+									StringBuilder sb = null;
+
+									for (Integer color : allColors) {
+										if (color == null)
+											continue;
+										if (sb == null)
+											sb = new StringBuilder("Color List:");
+										sb.append("\r\n#" + Integer.toHexString(color).toUpperCase());
+									}
+
+									if (sb != null)
+										Toast.makeText(getApplicationContext(), sb.toString(), Toast.LENGTH_SHORT).show();
+								}
 							}
 						})
 						.setNegativeButton("cancel", new DialogInterface.OnClickListener() {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,4 +21,5 @@ android {
 dependencies {
 	compile fileTree(dir: 'libs', include: ['*.jar'])
 	compile 'com.android.support:appcompat-v7:22.0.0'
+	compile 'com.rengwuxian.materialedittext:library:2.0.3'
 }

--- a/library/src/main/java/com/flask/colorpicker/ColorPickerView.java
+++ b/library/src/main/java/com/flask/colorpicker/ColorPickerView.java
@@ -9,6 +9,7 @@ import android.graphics.PorterDuff;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
+import android.widget.Toast;
 
 import com.flask.colorpicker.builder.PaintBuilder;
 import com.flask.colorpicker.renderer.ColorWheelRenderOption;
@@ -219,7 +220,7 @@ public class ColorPickerView extends View {
 		float[] hsv = new float[3];
 		Color.colorToHSV(color, hsv);
 
-		this.alpha = (color >> 24 & 0xff) / 255f;
+		this.alpha = Utils.getAlphaPercent(color);
 		this.initialColor = color;
 		this.lightness = hsv[2];
 		if (renderer.getColorCircleList() != null)
@@ -231,6 +232,12 @@ public class ColorPickerView extends View {
 		this.initialColor = Color.HSVToColor(getAlphaValueAsInt(), currentColorCircle.getHsvWithLightness(lightness));
 		if (this.colorEdit != null)
 			this.colorEdit.setText("#" + Integer.toHexString(this.initialColor).toUpperCase());
+		if (this.alphaSlider != null && this.initialColor != null)
+			this.alphaSlider.setColor(this.initialColor);
+		else if (this.alphaSlider == null)
+			Toast.makeText(this.getContext(), "something weird happened", Toast.LENGTH_SHORT).show();
+		else if (this.initialColor == null)
+			Toast.makeText(this.getContext(), "something weirder happened", Toast.LENGTH_SHORT).show();
 		updateColorWheel();
 		invalidate();
 	}
@@ -246,6 +253,8 @@ public class ColorPickerView extends View {
 		this.initialColor = Color.HSVToColor(getAlphaValueAsInt(), currentColorCircle.getHsvWithLightness(this.lightness));
 		if (this.colorEdit != null)
 			this.colorEdit.setText("#" + Integer.toHexString(this.initialColor).toUpperCase());
+		if (this.lightnessSlider != null && this.initialColor != null)
+			this.lightnessSlider.setColor(this.initialColor);
 		updateColorWheel();
 		invalidate();
 	}

--- a/library/src/main/java/com/flask/colorpicker/ColorPickerView.java
+++ b/library/src/main/java/com/flask/colorpicker/ColorPickerView.java
@@ -301,10 +301,6 @@ public class ColorPickerView extends View {
 			this.colorEdit.setText("#" + Integer.toHexString(this.initialColor).toUpperCase());
 		if (this.alphaSlider != null && this.initialColor != null)
 			this.alphaSlider.setColor(this.initialColor);
-		else if (this.alphaSlider == null)
-			Toast.makeText(this.getContext(), "something weird happened", Toast.LENGTH_SHORT).show();
-		else if (this.initialColor == null)
-			Toast.makeText(this.getContext(), "something weirder happened", Toast.LENGTH_SHORT).show();
 		updateColorWheel();
 		invalidate();
 	}

--- a/library/src/main/java/com/flask/colorpicker/ColorPickerView.java
+++ b/library/src/main/java/com/flask/colorpicker/ColorPickerView.java
@@ -6,9 +6,14 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
+import android.graphics.drawable.ColorDrawable;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.Toast;
 
 import com.flask.colorpicker.builder.PaintBuilder;
@@ -31,7 +36,9 @@ public class ColorPickerView extends View {
 	private float alpha = 1;
 	private int backgroundColor = 0x00000000;
 
-	private Integer initialColor = null;
+	private Integer initialColors[] = new Integer[] { null, null, null, null, null };
+	private int colorSelection = 0;
+	private Integer initialColor;
 	private Paint colorWheelFill = PaintBuilder.newPaint().color(0).build();
 	private Paint selectorStroke1 = PaintBuilder.newPaint().color(0xffffffff).build();
 	private Paint selectorStroke2 = PaintBuilder.newPaint().color(0xff000000).build();
@@ -41,6 +48,27 @@ public class ColorPickerView extends View {
 	private LightnessSlider lightnessSlider;
 	private AlphaSlider alphaSlider;
 	private MaterialEditText colorEdit;
+	private TextWatcher colorTextChange = new TextWatcher() {
+		@Override
+		public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+		}
+
+		@Override
+		public void onTextChanged(CharSequence s, int start, int before, int count) {
+		}
+
+		@Override
+		public void afterTextChanged(Editable s) {
+			try {
+				if (s == null)
+					return;
+				int color = Color.parseColor(s.toString());
+				setColor(color);
+			} catch (Exception e) {
+			}
+		}
+	};
+	private LinearLayout colorPreview;
 
 	private ColorWheelRenderer renderer;
 
@@ -63,7 +91,12 @@ public class ColorPickerView extends View {
 	}
 
 	private void updateColorWheel() {
-		int width = getWidth();
+		int width = getMeasuredWidth();
+		int height = getMeasuredHeight();
+		if (height < width)
+			width = height;
+		if (width <= 0)
+			return;
 		if (colorWheel == null) {
 			colorWheel = Bitmap.createBitmap(width, width, Bitmap.Config.ARGB_8888);
 			colorWheelCanvas = new Canvas(colorWheel);
@@ -112,7 +145,19 @@ public class ColorPickerView extends View {
 			width = MeasureSpec.getSize(widthMeasureSpec);
 		else if (widthMode == MeasureSpec.EXACTLY)
 			width = MeasureSpec.getSize(widthMeasureSpec);
-		setMeasuredDimension(width, width);
+
+		int heightMode = MeasureSpec.getMode(heightMeasureSpec);
+		int height = 0;
+		if (heightMode == MeasureSpec.UNSPECIFIED)
+			height = widthMeasureSpec;
+		else if (heightMode == MeasureSpec.AT_MOST)
+			height = MeasureSpec.getSize(heightMeasureSpec);
+		else if (widthMode == MeasureSpec.EXACTLY)
+			height = MeasureSpec.getSize(heightMeasureSpec);
+		int squareDimen = width;
+		if (height < width)
+			squareDimen = height;
+		setMeasuredDimension(squareDimen, squareDimen);
 	}
 
 	@Override
@@ -142,6 +187,8 @@ public class ColorPickerView extends View {
 					lightnessSlider.setColor(getSelectedColor());
 				if (alphaSlider != null)
 					alphaSlider.setColor(getSelectedColor());
+				setColorText(getSelectedColor(), true);
+				setColorPreviewColor(getSelectedColor());
 				invalidate();
 				break;
 			}
@@ -216,15 +263,35 @@ public class ColorPickerView extends View {
 		return getAlphaValueAsInt() << 24 | (0x00ffffff & color);
 	}
 
+	public Integer[] getAllColors() {
+		return initialColors;
+	}
+
+
+	public void setInitialColors(Integer[] colors, int selectedColor) {
+
+		this.initialColors = colors;
+		this.colorSelection = selectedColor;
+		setInitialColor(this.initialColors[this.colorSelection]);
+	}
+
 	public void setInitialColor(int color) {
 		float[] hsv = new float[3];
 		Color.colorToHSV(color, hsv);
 
 		this.alpha = Utils.getAlphaPercent(color);
-		this.initialColor = color;
 		this.lightness = hsv[2];
+		this.initialColors[this.colorSelection] = color;
+		this.initialColor = color;
+		setColorPreviewColor(color);
+		if (this.alphaSlider != null)
+			this.alphaSlider.setColor(color);
+		if (this.lightnessSlider != null)
+			this.lightnessSlider.setColor(color);
+		if (this.colorEdit != null)
+			setColorText(color, true);
 		if (renderer.getColorCircleList() != null)
-			currentColorCircle = findNearestByColor(initialColor);
+			currentColorCircle = findNearestByColor(color);
 	}
 
 	public void setLightness(float lightness) {
@@ -289,6 +356,96 @@ public class ColorPickerView extends View {
 	public void setRenderer(ColorWheelRenderer renderer) {
 		this.renderer = renderer;
 		invalidate();
+	}
+
+	public void setColorPreview(LinearLayout colorPreview, Integer selectedColor) {
+		if (colorPreview == null)
+			return;
+		this.colorPreview = colorPreview;
+		if (selectedColor == null)
+			selectedColor = 0;
+		int children = colorPreview.getChildCount();
+		if (children == 0 || colorPreview.getVisibility() != View.VISIBLE)
+			return;
+
+		for (int i = 0; i < children; i++) {
+			View childView = colorPreview.getChildAt(i);
+			if (!(childView instanceof LinearLayout))
+				continue;
+			LinearLayout childLayout = (LinearLayout)childView;
+			if (i == selectedColor) {
+				childLayout.setBackgroundColor(Color.YELLOW);
+			}
+			ImageView childImage = (ImageView)childLayout.findViewById(R.id.image_preview);
+			childImage.setClickable(true);
+			childImage.setTag(i);
+			childImage.setOnClickListener(new OnClickListener() {
+				@Override
+				public void onClick(View v) {
+					if (v == null)
+						return;
+					Object tag = v.getTag();
+					if (tag == null || !(tag instanceof Integer))
+						return;
+					setSelectedColor((int)tag);
+				}
+			});
+		}
+	}
+
+	public void setSelectedColor(int previewNumber) {
+		if (initialColors == null || initialColors.length < previewNumber)
+			return;
+		this.colorSelection = previewNumber;
+		setHighlightedColor(previewNumber);
+		Integer color = initialColors[previewNumber];
+		if (color == null)
+			return;
+		setColor(color);
+	}
+
+	private void setHighlightedColor(int previewNumber) {
+		int children = colorPreview.getChildCount();
+		if (children == 0 || colorPreview.getVisibility() != View.VISIBLE)
+			return;
+
+		for (int i = 0; i < children; i++) {
+			View childView = colorPreview.getChildAt(i);
+			if (!(childView instanceof LinearLayout))
+				continue;
+			LinearLayout childLayout = (LinearLayout)childView;
+			if (i == previewNumber) {
+				childLayout.setBackgroundColor(Color.YELLOW);
+			} else {
+				childLayout.setBackgroundColor(Color.TRANSPARENT);
+			}
+		}
+	}
+
+	private void setColorPreviewColor(int newColor) {
+		if (colorPreview == null || initialColors == null || colorSelection > initialColors.length || initialColors[colorSelection] == null)
+			return;
+
+		int children = colorPreview.getChildCount();
+		if (children == 0 || colorPreview.getVisibility() != View.VISIBLE)
+			return;
+
+		View childView = colorPreview.getChildAt(colorSelection);
+		if (!(childView instanceof LinearLayout))
+			return;
+		LinearLayout childLayout = (LinearLayout)childView;
+		ImageView childImage = (ImageView)childLayout.findViewById(R.id.image_preview);
+		childImage.setImageDrawable(new ColorDrawable(newColor));
+	}
+
+	private void setColorText(int argb, boolean internal) {
+		if (colorEdit == null)
+			return;
+		if (internal)
+			colorEdit.removeTextChangedListener(colorTextChange);
+		colorEdit.setText("#" + Integer.toHexString(argb));
+		if (internal)
+			colorEdit.addTextChangedListener(colorTextChange);
 	}
 
 	public enum WHEEL_TYPE {

--- a/library/src/main/java/com/flask/colorpicker/ColorPickerView.java
+++ b/library/src/main/java/com/flask/colorpicker/ColorPickerView.java
@@ -370,7 +370,7 @@ public class ColorPickerView extends View {
 				continue;
 			LinearLayout childLayout = (LinearLayout)childView;
 			if (i == selectedColor) {
-				childLayout.setBackgroundColor(Color.YELLOW);
+				childLayout.setBackgroundColor(Color.WHITE);
 			}
 			ImageView childImage = (ImageView)childLayout.findViewById(R.id.image_preview);
 			childImage.setClickable(true);
@@ -411,7 +411,7 @@ public class ColorPickerView extends View {
 				continue;
 			LinearLayout childLayout = (LinearLayout)childView;
 			if (i == previewNumber) {
-				childLayout.setBackgroundColor(Color.YELLOW);
+				childLayout.setBackgroundColor(Color.WHITE);
 			} else {
 				childLayout.setBackgroundColor(Color.TRANSPARENT);
 			}

--- a/library/src/main/java/com/flask/colorpicker/Utils.java
+++ b/library/src/main/java/com/flask/colorpicker/Utils.java
@@ -1,0 +1,25 @@
+package com.flask.colorpicker;
+
+import android.graphics.Color;
+
+/**
+ * Created by Charles Andersons on 4/17/15.
+ */
+public class Utils {
+    public static float getAlphaPercent(int argb) {
+        return Color.alpha(argb) / 255f;
+    }
+
+    public static int colorAtLightness(int color, float lightness) {
+        float[] hsv = new float[3];
+        Color.colorToHSV(color, hsv);
+        hsv[2] = lightness;
+        return Color.HSVToColor(hsv);
+    }
+
+    public static float lightnessOfColor(int color) {
+        float[] hsv = new float[3];
+        Color.colorToHSV(color, hsv);
+        return hsv[2];
+    }
+}

--- a/library/src/main/java/com/flask/colorpicker/builder/ColorPickerClickListener.java
+++ b/library/src/main/java/com/flask/colorpicker/builder/ColorPickerClickListener.java
@@ -1,0 +1,10 @@
+package com.flask.colorpicker.builder;
+
+import android.content.DialogInterface;
+
+/**
+ * Created by Charles Anderson on 4/17/15.
+ */
+public interface ColorPickerClickListener {
+    void onClick(DialogInterface d, int lastSelectedColor, Integer[] allColors);
+}

--- a/library/src/main/java/com/flask/colorpicker/builder/ColorPickerDialogBuilder.java
+++ b/library/src/main/java/com/flask/colorpicker/builder/ColorPickerDialogBuilder.java
@@ -4,11 +4,12 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.Color;
-import android.text.Editable;
+import android.graphics.drawable.ColorDrawable;
 import android.text.InputFilter;
-import android.text.TextWatcher;
+import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 
 import com.flask.colorpicker.ColorPickerView;
@@ -26,58 +27,43 @@ public class ColorPickerDialogBuilder {
 	private LightnessSlider lightnessSlider;
 	private AlphaSlider alphaSlider;
 	private MaterialEditText colorEdit;
+	private LinearLayout colorPreview;
 
 	private boolean isLightnessSliderEnabled = true;
 	private boolean isAlphaSliderEnabled = true;
 	private boolean isColorEditEnabled = false;
+	private boolean isPreviewEnabled = false;
+	private int pickerCount = 5;
 	private int defaultMargin = 0;
-	private int initialColor;
+	private Integer[] initialColor = new Integer[] { null, null, null, null, null};
 
 	private ColorPickerDialogBuilder(Context context) {
 		builder = new AlertDialog.Builder(context);
 		pickerContainer = new LinearLayout(context);
 		pickerContainer.setOrientation(LinearLayout.VERTICAL);
+		pickerContainer.setGravity(Gravity.CENTER_HORIZONTAL);
 		defaultMargin = getDimensionAsPx(context, R.dimen.default_slider_margin);
 
-		LinearLayout.LayoutParams layoutParamsForColorPickerView = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+		LinearLayout.LayoutParams layoutParamsForColorPickerView = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0);
+		layoutParamsForColorPickerView.weight = 1;
 		colorPickerView = new ColorPickerView(context);
 
 		pickerContainer.addView(colorPickerView, layoutParamsForColorPickerView);
+
+		colorPreview = (LinearLayout)View.inflate(context, R.layout.color_preview, null);
+		colorPreview.setVisibility(View.GONE);
+		pickerContainer.addView(colorPreview);
 
 		LinearLayout.LayoutParams layoutParamsForColorEdit = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
 		int padSide = getDimensionAsPx(context, R.dimen.default_padding_side);
 		layoutParamsForColorEdit.leftMargin = padSide;
 		layoutParamsForColorEdit.rightMargin = padSide;
 		colorEdit = (MaterialEditText)View.inflate(context, R.layout.picker_edit, null);
-		colorEdit.setFilters(new InputFilter[] {new InputFilter.AllCaps()});
+		colorEdit.setFilters(new InputFilter[]{new InputFilter.AllCaps()});
 		colorEdit.setMaxCharacters(9);
-		colorPickerView.addOnColorSelectedListener(new OnColorSelectedListener() {
-			@Override
-			public void onColorSelected(int selectedColor) {
-				colorEdit.setText("#" + Integer.toHexString(selectedColor).toUpperCase());
-			}
-		});
-		colorEdit.addTextChangedListener(new TextWatcher() {
-			@Override
-			public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
-
-			@Override
-			public void onTextChanged(CharSequence s, int start, int before, int count) {}
-
-			@Override
-			public void afterTextChanged(Editable s) {
-				try {
-					if (s == null)
-						return;
-					int color = Color.parseColor(s.toString());
-					if (colorPickerView != null)
-						colorPickerView.setColor(color);
-				} catch (Exception e) {
-				}
-			}
-		});
 		colorEdit.setVisibility(View.GONE);
 		pickerContainer.addView(colorEdit, layoutParamsForColorEdit);
+
 		builder.setView(pickerContainer);
 	}
 
@@ -91,7 +77,15 @@ public class ColorPickerDialogBuilder {
 	}
 
 	public ColorPickerDialogBuilder initialColor(int initialColor) {
-		this.initialColor = initialColor;
+		this.initialColor[0] = initialColor;
+		return this;
+	}
+
+
+	public ColorPickerDialogBuilder initialColors(int[] initialColor) {
+		for (int i = 0; i < initialColor.length && i < this.initialColor.length; i++) {
+			this.initialColor[i] = initialColor[i];
+		}
 		return this;
 	}
 
@@ -111,12 +105,13 @@ public class ColorPickerDialogBuilder {
 		return this;
 	}
 
-	public ColorPickerDialogBuilder setPositiveButton(String text, final DialogInterface.OnClickListener onClickListener) {
+	public ColorPickerDialogBuilder setPositiveButton(String text, final ColorPickerClickListener onClickListener) {
 		builder.setPositiveButton(text, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int which) {
 				int selectedColor = colorPickerView.getSelectedColor();
-				onClickListener.onClick(dialog, selectedColor);
+				Integer[] allColors = colorPickerView.getAllColors();
+				onClickListener.onClick(dialog, selectedColor, allColors);
 			}
 		});
 		return this;
@@ -160,9 +155,25 @@ public class ColorPickerDialogBuilder {
 		return this;
 	}
 
+	public ColorPickerDialogBuilder showColorPreview(boolean showPreview) {
+		isPreviewEnabled = showPreview;
+		if (!showPreview)
+			pickerCount = 1;
+		return this;
+	}
+
+	public ColorPickerDialogBuilder setPickerCount(int pickerCount) throws IndexOutOfBoundsException {
+		if (pickerCount < 1 || pickerCount > 5)
+			throw new IndexOutOfBoundsException("Picker Can Only Support 1-5 Colors");
+		this.pickerCount = pickerCount;
+		if (this.pickerCount > 1)
+			this.isPreviewEnabled = true;
+		return this;
+	}
+
 	public AlertDialog build() {
 		Context context = builder.getContext();
-		colorPickerView.setInitialColor(initialColor);
+		colorPickerView.setInitialColors(initialColor, getStartOffset(initialColor));
 
 		if (isLightnessSliderEnabled) {
 			LinearLayout.LayoutParams layoutParamsForLightnessBar = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, getDimensionAsPx(context, R.dimen.default_slider_height));
@@ -171,7 +182,7 @@ public class ColorPickerDialogBuilder {
 			lightnessSlider.setLayoutParams(layoutParamsForLightnessBar);
 			pickerContainer.addView(lightnessSlider);
 			colorPickerView.setLightnessSlider(lightnessSlider);
-			lightnessSlider.setColor(initialColor);
+			lightnessSlider.setColor(getStartColor(initialColor));
 		}
 		if (isAlphaSliderEnabled) {
 			LinearLayout.LayoutParams layoutParamsForAlphaBar = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, getDimensionAsPx(context, R.dimen.default_slider_height));
@@ -180,15 +191,53 @@ public class ColorPickerDialogBuilder {
 			alphaSlider.setLayoutParams(layoutParamsForAlphaBar);
 			pickerContainer.addView(alphaSlider);
 			colorPickerView.setAlphaSlider(alphaSlider);
-			alphaSlider.setColor(initialColor);
+			alphaSlider.setColor(getStartColor(initialColor));
 		}
 
 		if (isColorEditEnabled) {
-			colorEdit.setText("#" + Integer.toHexString(initialColor).toUpperCase());
+			colorEdit.setText("#" + Integer.toHexString(getStartColor(initialColor)).toUpperCase());
 			colorPickerView.setColorEdit(colorEdit);
 		}
 
+		if (isPreviewEnabled) {
+			if (initialColor.length == 0) {
+				ImageView colorImage = (ImageView) View.inflate(context, R.layout.color_selector, null);
+				colorImage.setImageDrawable(new ColorDrawable(Color.WHITE));
+			} else {
+				for (int i = 0; i < initialColor.length && i < this.pickerCount; i++) {
+					if (initialColor[i] == null)
+						break;
+					LinearLayout colorLayout = (LinearLayout) View.inflate(context, R.layout.color_selector, null);
+					ImageView colorImage = (ImageView)colorLayout.findViewById(R.id.image_preview);
+					colorImage.setImageDrawable(new ColorDrawable(initialColor[i]));
+					colorPreview.addView(colorLayout);
+				}
+			}
+			colorPreview.setVisibility(View.VISIBLE);
+			colorPickerView.setColorPreview(colorPreview, getStartOffset(initialColor));
+		}
+
+		if (isPreviewEnabled) {
+
+		}
+
 		return builder.create();
+	}
+
+	private Integer getStartOffset(Integer[] colors) {
+		Integer start = null;
+		for (int i = 0; i < colors.length; i++) {
+			if (colors[i] == null) {
+				return start;
+			}
+			start = (i + 1) / 2;
+		}
+		return start;
+	}
+
+	private int getStartColor(Integer[] colors) {
+		Integer startColor = getStartOffset(colors);
+		return startColor == null ? Color.WHITE : colors[startColor];
 	}
 
 	private static int getDimensionAsPx(Context context, int rid) {

--- a/library/src/main/java/com/flask/colorpicker/builder/ColorPickerDialogBuilder.java
+++ b/library/src/main/java/com/flask/colorpicker/builder/ColorPickerDialogBuilder.java
@@ -33,7 +33,7 @@ public class ColorPickerDialogBuilder {
 	private boolean isAlphaSliderEnabled = true;
 	private boolean isColorEditEnabled = false;
 	private boolean isPreviewEnabled = false;
-	private int pickerCount = 5;
+	private int pickerCount = 1;
 	private int defaultMargin = 0;
 	private Integer[] initialColor = new Integer[] { null, null, null, null, null};
 

--- a/library/src/main/java/com/flask/colorpicker/slider/AlphaSlider.java
+++ b/library/src/main/java/com/flask/colorpicker/slider/AlphaSlider.java
@@ -4,13 +4,14 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapShader;
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
-import android.graphics.PorterDuffXfermode;
 import android.graphics.Shader;
 import android.util.AttributeSet;
 
 import com.flask.colorpicker.ColorPickerView;
+import com.flask.colorpicker.Utils;
 import com.flask.colorpicker.builder.PaintBuilder;
 
 public class AlphaSlider extends AbsCustomSlider {
@@ -96,14 +97,10 @@ public class AlphaSlider extends AbsCustomSlider {
 
 	public void setColor(int color) {
 		this.color = color;
-		this.value = alphaOfColor(color);
+		this.value = Utils.getAlphaPercent(color);
 		if (bar != null) {
 			updateBar();
 			invalidate();
 		}
-	}
-
-	private float alphaOfColor(int color) {
-		return (color >> 24 & 0xff) / 255f;
 	}
 }

--- a/library/src/main/java/com/flask/colorpicker/slider/LightnessSlider.java
+++ b/library/src/main/java/com/flask/colorpicker/slider/LightnessSlider.java
@@ -8,6 +8,7 @@ import android.graphics.PorterDuff;
 import android.util.AttributeSet;
 
 import com.flask.colorpicker.ColorPickerView;
+import com.flask.colorpicker.Utils;
 import com.flask.colorpicker.builder.PaintBuilder;
 
 public class LightnessSlider extends AbsCustomSlider {
@@ -52,7 +53,7 @@ public class LightnessSlider extends AbsCustomSlider {
 
 	@Override
 	protected void drawHandle(Canvas canvas, float x, float y) {
-		solid.setColor(colorAtLightness(color, value));
+		solid.setColor(Utils.colorAtLightness(color, value));
 		canvas.drawCircle(x, y, handleRadius, stroke1);
 		canvas.drawCircle(x, y, handleRadius * 0.75f, solid);
 	}
@@ -63,23 +64,11 @@ public class LightnessSlider extends AbsCustomSlider {
 
 	public void setColor(int color) {
 		this.color = color;
-		this.value = lightnessOfColor(color);
+		this.value = Utils.lightnessOfColor(color);
 		if (bar != null) {
 			updateBar();
 			invalidate();
 		}
 	}
 
-	private int colorAtLightness(int color, float lightness) {
-		float[] hsv = new float[3];
-		Color.colorToHSV(color, hsv);
-		hsv[2] = lightness;
-		return Color.HSVToColor(hsv);
-	}
-
-	private float lightnessOfColor(int color) {
-		float[] hsv = new float[3];
-		Color.colorToHSV(color, hsv);
-		return hsv[2];
-	}
 }

--- a/library/src/main/res/layout/color_preview.xml
+++ b/library/src/main/res/layout/color_preview.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
+    android:layout_width="wrap_content"
+    android:layout_height="@dimen/default_preview_height"
+    android:gravity="center"
+    android:background="@android:color/transparent">
+</LinearLayout>

--- a/library/src/main/res/layout/color_selector.xml
+++ b/library/src/main/res/layout/color_selector.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="@dimen/default_preview_height"
+    android:layout_height="@dimen/default_preview_height"
+    android:background="@android:color/transparent"
+    android:padding="2dp">
+    <ImageView
+        android:layout_width="@dimen/default_preview_image_height"
+        android:layout_height="@dimen/default_preview_image_height"
+        android:src="@android:color/transparent"
+        android:id="@+id/image_preview"/>
+</LinearLayout>

--- a/library/src/main/res/layout/picker_edit.xml
+++ b/library/src/main/res/layout/picker_edit.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.rengwuxian.materialedittext.MaterialEditText
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/PickerEditText"
+    app:met_floatingLabelAlwaysShown="true"
+    android:hint="Color Value"/>

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -5,4 +5,6 @@
 	<dimen name="default_slider_bar_height">4dp</dimen>
 	<dimen name="default_slider_handler_radius">10dp</dimen>
 	<dimen name="default_padding_side">10dp</dimen>
+	<dimen name="default_preview_height">40dp</dimen>
+	<dimen name="default_preview_image_height">36dp</dimen>
 </resources>

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -4,4 +4,5 @@
 	<dimen name="default_slider_margin">4dp</dimen>
 	<dimen name="default_slider_bar_height">4dp</dimen>
 	<dimen name="default_slider_handler_radius">10dp</dimen>
+	<dimen name="default_padding_side">10dp</dimen>
 </resources>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="PickerEditText">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_margin">4dp</item>
+        <item name="android:imeOptions">actionNext</item>
+        <item name="android:singleLine">true</item>
+        <item name="android:textSize">22sp</item>
+        <item name="met_baseColor">@android:color/white</item>
+        <item name="met_floatingLabel">normal</item>
+        <item name="met_primaryColor">@android:color/white</item>
+    </style>
+</resources>


### PR DESCRIPTION
- Gives the user the option to fine tune the color, and can be a reasonable resolution to Issue #5 
- Simplify alpha calculation using Color library
- Add alpha slider color change when changing lightness (Resolves Issue #9 )
- Add color-preview row to show a swatch of color (Resolves Issue #8 )
- Add multi-select interface for up to 5 colors, more could be added, but this seemed a reasonable limit (Resolves Issue #7 )
- New click-listener for multi-select compatibility, not backwards compatible. 
- Added better size calculation for ColorWheel itself by letting it scale up to the max dimensions requested, but staying square. This will support many more screen sizes/densities.
