### PR TITLE
Fix currentColorCircle changing when it shouldn't

### DIFF
--- a/library/src/main/java/com/flask/colorpicker/ColorPickerView.java
+++ b/library/src/main/java/com/flask/colorpicker/ColorPickerView.java
@@ -120,6 +120,7 @@ public class ColorPickerView extends View {
 	public void onWindowFocusChanged(boolean hasWindowFocus) {
 		super.onWindowFocusChanged(hasWindowFocus);
 		updateColorWheel();
+		currentColorCircle = findNearestByColor(initialColor);
 	}
 
 	private void updateColorWheel() {
@@ -159,14 +160,6 @@ public class ColorPickerView extends View {
 		renderer.initWith(colorWheelRenderOption);
 
 		renderer.draw();
-
-		if (initialColor != null) {
-			currentColorCircle = findNearestByColor(initialColor);
-			float[] hsv = new float[3];
-			Color.colorToHSV(initialColor, hsv);
-			currentColorCircle.set(currentColorCircle.getX(), currentColorCircle.getY(), hsv);
-			initialColor = null;
-		}
 	}
 
 	@Override
@@ -200,8 +193,9 @@ public class ColorPickerView extends View {
 		switch (event.getAction()) {
 			case MotionEvent.ACTION_DOWN:
 			case MotionEvent.ACTION_MOVE: {
-				int selectedColor = getSelectedColor();
 				currentColorCircle = findNearestByPosition(event.getX(), event.getY());
+				int selectedColor = getSelectedColor();
+				initialColor = selectedColor;
 				setColorToSliders(selectedColor);
 				invalidate();
 				break;


### PR DESCRIPTION
Previously, moving the value bar would occasionally change which color circle was selected:
![pre-fix-compressed](https://cloud.githubusercontent.com/assets/2219904/7904088/780c0d2c-07bd-11e5-9b43-f16f50e12736.gif)

This fixes that.

![post-fix-compressed](https://cloud.githubusercontent.com/assets/2219904/7904089/7dd7a112-07bd-11e5-93fa-20fe99213f61.gif)
