### PR TITLE
Initialize colorCircleList earlier to avoid race condition NPE

### DIFF
--- a/library/src/main/java/com/flask/colorpicker/renderer/AbsColorWheelRenderer.java
+++ b/library/src/main/java/com/flask/colorpicker/renderer/AbsColorWheelRenderer.java
@@ -7,11 +7,11 @@ import java.util.List;
 
 public abstract class AbsColorWheelRenderer implements ColorWheelRenderer {
 	protected ColorWheelRenderOption colorWheelRenderOption;
-	protected List<ColorCircle> colorCircleList;
+	protected List<ColorCircle> colorCircleList = new ArrayList<>();
 
 	public void initWith(ColorWheelRenderOption colorWheelRenderOption) {
 		this.colorWheelRenderOption = colorWheelRenderOption;
-		this.colorCircleList = new ArrayList<>();
+		this.colorCircleList.clear();
 	}
 
 	@Override


### PR DESCRIPTION
A race condition on ColorPickerView makes apps crash
### How to reproduce
- Open the color picker sample
- Tap multiple times quickly on `Open dialog sample`or `Open view sample` buttons

It may require many tries to reproduce.
I personally had this crash a few times unintentionally.

```
com.flask.colorpicker.sample E/AndroidRuntime: FATAL EXCEPTION: main
Process: com.flask.colorpicker.sample, PID: 22545
java.lang.NullPointerException: Attempt to invoke interface method 'java.util.Iterator java.util.List.iterator()' on a null object reference
    at com.flask.colorpicker.ColorPickerView.findNearestByPosition(ColorPickerView.java:261)
    at com.flask.colorpicker.ColorPickerView.onTouchEvent(ColorPickerView.java:210)
    at android.view.View.dispatchTouchEvent(View.java:9993)
```

This PR makes sure the `AbsColorWheelRenderer.colorCircleList` is never null
