### PR TITLE
Update color wheel bitmap size in case view size changes

### DIFF
--- a/library/src/main/java/com/flask/colorpicker/ColorPickerView.java
+++ b/library/src/main/java/com/flask/colorpicker/ColorPickerView.java
@@ -158,12 +158,12 @@ public class ColorPickerView extends View {
 			width = height;
 		if (width <= 0)
 			return;
-		if (colorWheel == null) {
+		if (colorWheel == null || colorWheel.getWidth() != width) {
 			colorWheel = Bitmap.createBitmap(width, width, Bitmap.Config.ARGB_8888);
 			colorWheelCanvas = new Canvas(colorWheel);
 			alphaPatternPaint.setShader(PaintBuilder.createAlphaPatternShader(26));
 		}
-		if (currentColor == null) {
+		if (currentColor == null || currentColor.getWidth() != width) {
 			currentColor = Bitmap.createBitmap(width, width, Bitmap.Config.ARGB_8888);
 			currentColorCanvas = new Canvas(currentColor);
 		}


### PR DESCRIPTION
If color picker view size changes the color wheel gets redrawn. 
But existing logic does not update color wheel bitmap size for new available view size, resulting in the same bitmap being drawn. 
When the bitmap gets drawn on screen it does not match the available view space, it either is too small or parts are cut off...  

Code update recreates the bitmap with the actual view size dimensions.