### PR TITLE
Add minimumWheelLightness

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-	compileSdkVersion 29
-	buildToolsVersion "29.0.0"
+	compileSdkVersion 30
+	buildToolsVersion "29.0.2"
 
 	defaultConfig {
 		applicationId "com.flask.colorpicker.sample"
 		minSdkVersion 14
-		targetSdkVersion 29
+		targetSdkVersion 30
 		versionCode 10
 		versionName "1.0.10"
 

--- a/app/src/main/res/layout/activity_sample2.xml
+++ b/app/src/main/res/layout/activity_sample2.xml
@@ -12,6 +12,7 @@
 		android:layout_height="wrap_content"
 		app:alphaSlider="true"
 		app:density="12"
+		app:minimumWheelLightness="0.05"
 		app:lightnessSlider="true"
 		app:wheelType="FLOWER"
 		app:lightnessSliderView="@+id/v_lightness_slider"

--- a/app/src/main/res/layout/activity_sample2.xml
+++ b/app/src/main/res/layout/activity_sample2.xml
@@ -12,7 +12,7 @@
 		android:layout_height="wrap_content"
 		app:alphaSlider="true"
 		app:density="12"
-		app:minimumWheelLightness="0.05"
+		app:minimumWheelLightness="0.01"
 		app:lightnessSlider="true"
 		app:wheelType="FLOWER"
 		app:lightnessSliderView="@+id/v_lightness_slider"

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
 	}
 	dependencies {
 		classpath 'com.android.tools.build:gradle:7.2.2'
+		classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
 
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 		google()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:3.5.2'
+		classpath 'com.android.tools.build:gradle:7.2.2'
 
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files
@@ -17,5 +17,6 @@ allprojects {
 	repositories {
 		jcenter()
 		google()
+		maven { url "https://jitpack.io" }
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Thu Nov 07 22:59:21 KST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,12 +1,13 @@
 apply plugin: 'com.android.library'
+apply plugin: 'maven-publish'
 
 android {
-	compileSdkVersion 29
-	buildToolsVersion "29.0.0"
+	compileSdkVersion 30
+	buildToolsVersion "29.0.2"
 
 	defaultConfig {
 		minSdkVersion 14
-		targetSdkVersion 29
+		targetSdkVersion 30
 		versionCode 17
 		versionName "0.0.15"
 	}

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
-apply plugin: 'maven-publish'
+
+group='com.github.QuadFlask'
 
 android {
 	compileSdkVersion 30
@@ -22,4 +23,7 @@ android {
 dependencies {
 	implementation fileTree(dir: 'libs', include: ['*.jar'])
 	implementation 'androidx.appcompat:appcompat:1.1.0'
+}
+repositories {
+	mavenCentral()
 }

--- a/library/src/main/java/com/flask/colorpicker/ColorPickerView.java
+++ b/library/src/main/java/com/flask/colorpicker/ColorPickerView.java
@@ -43,6 +43,7 @@ public class ColorPickerView extends View {
 	private Integer initialColors[] = new Integer[]{null, null, null, null, null};
 	private int colorSelection = 0;
 	private Integer initialColor;
+	private float minimumWheelLightness;
 	private Integer pickerColorEditTextColor;
 	private Paint colorWheelFill = PaintBuilder.newPaint().color(0).build();
 	private Paint selectorStroke = PaintBuilder.newPaint().color(0).build();
@@ -108,6 +109,7 @@ public class ColorPickerView extends View {
 
 		density = typedArray.getInt(R.styleable.ColorPickerPreference_density, 10);
 		initialColor = typedArray.getInt(R.styleable.ColorPickerPreference_initialColor, 0xffffffff);
+		minimumWheelLightness = typedArray.getFloat(R.styleable.ColorPickerPreference_minimumWheelLightness, 0.0f);
 
 		pickerColorEditTextColor = typedArray.getInt(R.styleable.ColorPickerPreference_pickerColorEditTextColor, 0xffffffff);
 
@@ -188,7 +190,7 @@ public class ColorPickerView extends View {
 		colorWheelRenderOption.cSize = cSize;
 		colorWheelRenderOption.strokeWidth = strokeWidth;
 		colorWheelRenderOption.alpha = alpha;
-		colorWheelRenderOption.lightness = lightness;
+		colorWheelRenderOption.lightness = lightness >= minimumWheelLightness ? lightness : 1.0f;
 		colorWheelRenderOption.targetCanvas = colorWheelCanvas;
 
 		renderer.initWith(colorWheelRenderOption);

--- a/library/src/main/java/com/flask/colorpicker/ColorPickerView.java
+++ b/library/src/main/java/com/flask/colorpicker/ColorPickerView.java
@@ -230,6 +230,7 @@ public class ColorPickerView extends View {
 			case MotionEvent.ACTION_MOVE: {
 				int lastSelectedColor = getSelectedColor();
 				currentColorCircle = findNearestByPosition(event.getX(), event.getY());
+				lightness = Utils.lightnessOfColor(currentColorCircle.getColor());
 				int selectedColor = getSelectedColor();
 
 				callOnColorChangedListeners(lastSelectedColor, selectedColor);

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -6,6 +6,7 @@
 		<attr name="border" format="boolean"/>
 		<attr name="density" format="integer"/>
 		<attr name="initialColor" format="integer"/>
+		<attr name="minimumWheelLightness" format="float"/>
 		<attr name="wheelType" format="enum">
 			<enum name="FLOWER" value="0"/>
 			<enum name="CIRCLE" value="1"/>


### PR DESCRIPTION
Firstly thanks for this library. It's great!

I'm using it as a text color picker. The default text color is black. The problem I had was when the user opens the text color picker for the first time, all the circles on the wheel were black as the wheel was set to the current text color. Users had to drag the lightness slider before revealing the colors they can choose from which wasn't intuitive.

This PR tackles this problem by adding an optional attribute to the ColorPickerView which will show the wheel colors at full lightness, except for the circle currently selected, when the lightness value drops below it. The idea is that when the lightness value is as low as 0.01 for example, the colors are indistinguishable so offering lots of buttons that effectively do the same thing is not that useful.

Hopefully this will help others too (https://github.com/QuadFlask/colorpicker/issues/109)

I also made changes to get this building with Jitpack